### PR TITLE
Chore: downgrade nextjs 15rc to 14

### DIFF
--- a/application/package-lock.json
+++ b/application/package-lock.json
@@ -8,16 +8,16 @@
       "name": "flyer-savvy",
       "version": "0.1.0",
       "dependencies": {
-        "next": "15.0.0-rc.0",
-        "react": "19.0.0-rc-f994737d14-20240522",
-        "react-dom": "19.0.0-rc-f994737d14-20240522"
+        "next": "^14.0.0",
+        "react": "^18.0.0",
+        "react-dom": "^18.0.0"
       },
       "devDependencies": {
         "@types/node": "^20",
         "@types/react": "^18",
         "@types/react-dom": "^18",
         "eslint": "^8",
-        "eslint-config-next": "15.0.0-rc.0",
+        "eslint-config-next": "14.2.5",
         "typescript": "^5"
       }
     },

--- a/application/package.json
+++ b/application/package.json
@@ -9,9 +9,9 @@
     "lint": "next lint"
   },
   "dependencies": {
-    "react": "19.0.0-rc-f994737d14-20240522",
-    "react-dom": "19.0.0-rc-f994737d14-20240522",
-    "next": "15.0.0-rc.0"
+    "react": "18.0.0",
+    "react-dom": "^18.0.0",
+    "next": "^14.0.0"
   },
   "devDependencies": {
     "typescript": "^5",
@@ -19,6 +19,6 @@
     "@types/react": "^18",
     "@types/react-dom": "^18",
     "eslint": "^8",
-    "eslint-config-next": "15.0.0-rc.0"
+    "eslint-config-next": "14.2.5"
   }
 }


### PR DESCRIPTION
Changed framework version
- Downgraded Next.js from version 15 RC to 14 to align with Drizzle ORM's peer dependencies.
- Resolves dependency conflicts and maintains project stability.