### PR TITLE
Refactor: extract transform functions to service layer

### DIFF
--- a/application/src/action/flyer.ts
+++ b/application/src/action/flyer.ts
@@ -1,38 +1,13 @@
-import * as ServerType from '@/types/server/flyer';
-import * as ClientType from '@/types/client/flyer';
-import * as Query from '@/lib/db/queries/flyer'
+import * as Server from '@/types/server/flyer';
+import * as Api from '@/types/client/api';
+import * as Query from '@/lib/db/queries/flyer';
+import * as Transform from '@/lib/utils/transform';
 
-export async function findAllFlyers():Promise<ClientType.Flyer[]|null>{
-    const flyers:ServerType.Flyer[] | null = await Query.GetAllFlyers();
+export async function findCurrentFlyers():Promise<Api.Flyer[]|null>{
+    const flyers:Server.Flyer[] | null = await Query.GetAllValidFlyers();
     if(flyers && flyers.length>0){
-        const clientFlyers: ClientType.Flyer[] = await Promise.all(flyers.map(transformFlyer));
+        const clientFlyers: Api.Flyer[] = await Promise.all(flyers.map(Transform.transformFlyer));
         return clientFlyers;
     }
     return null;
-}
-
-export async function findFlyer(flyerid:number):Promise<ClientType.Flyer|null>{
-    const flyer: ServerType.Flyer | null = await Query.GetFlyerByID(flyerid);
-    return flyer ? await transformFlyer(flyer) : null;
-}
-
-export async function findCurrentFlyers():Promise<ClientType.Flyer[]|null>{
-    const flyers:ServerType.Flyer[] | null = await Query.GetAllValidFlyers();
-    if(flyers && flyers.length>0){
-        const clientFlyers: ClientType.Flyer[] = await Promise.all(flyers.map(transformFlyer));
-        return clientFlyers;
-    }
-    return null;
-}
-
-
-//********move to service folder? 
-
-export async function transformFlyer(serverFlyer:ServerType.Flyer):Promise<ClientType.Flyer>{
-    const result : ClientType.Flyer= {
-        flyer_id: serverFlyer.flyer_id,
-        valid_from: serverFlyer.valid_from,
-        valid_to: serverFlyer.valid_to
-    }
-    return result;
 }

--- a/application/src/action/pointHistory.ts
+++ b/application/src/action/pointHistory.ts
@@ -1,21 +1,11 @@
 import * as Server from '@/types/server/product';
-import * as Client from '@/types/client/product';
+import * as Api from '@/types/client/api';
 import * as Query from '@/lib/db/queries/pointHistory'
 import { GetAllValidFlyerID } from '@/lib/db/queries/flyer';
-
-export async function findPointHistory(pointHistoryId:number):Promise<Client.PointHistory|null>{
-    const pointHistory:Server.PointHistory | null = await Query.GetPointHistoryByID(pointHistoryId);
-    return pointHistory? await transformPointHistory(pointHistory): null; 
-}
+import * as Transform from '@/lib/utils/transform';
 
 
-export async function findPointHistoryByProduct(product_id: number):Promise<Client.PointHistory[]|null>{
-    const pointHistory:Server.PointHistory[] | null = await Query.GetPointHistoryByProduct(product_id);
-    return pointHistory? await Promise.all(pointHistory.map(transformPointHistory)): null; 
-}
-
-
-export async function findCurrentPointHistory():Promise<Client.PointHistory[] | null>{
+export async function findCurrentPointHistory():Promise<Api.PointHistory[] | null>{
     // Fetch the current flyers
     const currentFlyerIDs : number[] | null = await GetAllValidFlyerID();
 
@@ -31,20 +21,10 @@ export async function findCurrentPointHistory():Promise<Client.PointHistory[] | 
         .flat() as Server.PointHistory[];
 
         // Transform the point histories if any are found
-        return currentPointHistories.length>0? await Promise.all(currentPointHistories.map(transformPointHistory)) : null;
+        return currentPointHistories.length>0? await Promise.all(currentPointHistories.map(Transform.transformPointHistory)) : null;
     }
     // Return null if no point histories are found or flyers are missing
     return null;
 }
 
 
-
-//********move to utils folder? 
-
-export async function transformPointHistory(serverPointHistory:Server.PointHistory):Promise<Client.PointHistory>{
-    const clientPointHistory : Client.PointHistory= {
-        point_history_id: serverPointHistory.point_history_id,
-        point: serverPointHistory.point
-    }
-    return clientPointHistory;
-}

--- a/application/src/action/priceHistory.ts
+++ b/application/src/action/priceHistory.ts
@@ -1,21 +1,11 @@
 import * as Server from '@/types/server/product';
-import * as Client from '@/types/client/product';
+import * as Api from '@/types/client/api';
 import * as Query from '@/lib/db/queries/priceHistory'
 import {GetAllValidFlyerID} from '@/lib/db/queries/flyer';
+import * as Transform from '@/lib/utils/transform';
 
 
-export async function findPriceHistory(priceHistoryId:number):Promise<Client.PriceHistory|null>{
-    const priceHistory:Server.PriceHistory | null = await Query.GetPriceHistoryByID(priceHistoryId);
-    return priceHistory? await transformPriceHistory(priceHistory): null; 
-}
-
-export async function findPriceHistoryByProduct(product_id: number):Promise<Client.PriceHistory[]|null>{
-    const priceHistory:Server.PriceHistory[] | null = await Query.GetPriceHistoryByProduct(product_id);
-    return priceHistory? await Promise.all(priceHistory.map(transformPriceHistory)): null; 
-}
-
-
-export async function findCurrentPriceHistory():Promise<Client.PriceHistory[] | null>{
+export async function findCurrentPriceHistory():Promise<Api.PriceHistory[] | null>{
     // Fetch the current flyers
     const currentFlyerIDs : number[] | null = await GetAllValidFlyerID();
 
@@ -30,20 +20,9 @@ export async function findCurrentPriceHistory():Promise<Client.PriceHistory[] | 
         .flat() as Server.PriceHistory[];
 
         // Transform the price histories if any are found
-        return currentPriceHistories.length>0? await Promise.all(currentPriceHistories.map(transformPriceHistory)) : null;
+        return currentPriceHistories.length>0? await Promise.all(currentPriceHistories.map(Transform.transformPriceHistory)) : null;
     }
     // Return null if no price histories are found or flyers are missing
     return null;
-}
-
-
-//********move to utils folder? 
-export async function transformPriceHistory(serverPriceHistory:Server.PriceHistory):Promise<Client.PriceHistory>{
-    const clientPriceHistory : Client.PriceHistory = {
-        price_history_id: serverPriceHistory.price_history_id,
-        price: serverPriceHistory.price,
-        unit: serverPriceHistory.unit
-    }
-    return clientPriceHistory;
 }
 

--- a/application/src/app/api/flyer/all/route.ts
+++ b/application/src/app/api/flyer/all/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server';
-import * as Action from '@/action/flyer'
+import * as Service from '@/service/server/flyer'
 import * as Response from '@/lib/http/responses'
 
 /**
@@ -13,7 +13,7 @@ import * as Response from '@/lib/http/responses'
 */
 export async function GET(request: NextRequest):Promise<NextResponse>  { 
     try{
-        const flyers = await Action.findAllFlyers();
+        const flyers = await Service.findAllFlyers();
         
         if (!flyers || flyers.length === 0) {
             return Response.notFoundResponse(404);

--- a/application/src/app/api/flyer/byID/[flyerID]/route.ts
+++ b/application/src/app/api/flyer/byID/[flyerID]/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server';
-import * as Action from '@/action/flyer'
+import * as Service from '@/service/server/flyer'
 import * as Response from '@/lib/http/responses'
 
 /**
@@ -21,19 +21,21 @@ export async function GET(request: NextRequest,
     const flyerIDInt = flyerID ? parseInt(flyerID, 10) : NaN;
 
     if(!flyerID || isNaN(flyerIDInt)) {
+        //will add error message in Logging entry later on
         return Response.badRequestResponse(400);
     }
     
     try{
-        const flyer = await Action.findFlyer(flyerIDInt);
+        const flyer = await Service.findFlyer(flyerIDInt);
         if (!flyer) {
+            //will add error message in Logging entry later on
             return Response.notFoundResponse(404);
         }
 
         return Response.successReponse(flyer, 200);
 
     } catch(error){
-        // This is temporarily approach, it will be handle in Logging entry later on
+        //will be handle in Logging entry later on
         console.error('Server error:', error);
         return Response.serverErrorReponse(500);
     }

--- a/application/src/app/api/pointHistory/byID/[pointHistoryID]/route.ts
+++ b/application/src/app/api/pointHistory/byID/[pointHistoryID]/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server';
-import * as Action from '@/action/pointHistory'
+import * as Service from '@/service/server/pointHistory'
 import * as Response from '@/lib/http/responses'
 
 /**
@@ -26,7 +26,7 @@ export async function GET(
     }
     
     try{
-        const pointHistory = await Action.findPointHistory(pointHistoryInt);
+        const pointHistory = await Service.findPointHistory(pointHistoryInt);
         
         if (!pointHistory) {
             return Response.notFoundResponse(404);

--- a/application/src/app/api/pointHistory/byProductID/[productID]/route.ts
+++ b/application/src/app/api/pointHistory/byProductID/[productID]/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server';
-import * as Action from '@/action/pointHistory'
-import * as Response from '@/lib/http/responses'
+import * as Service from '@/service/server/pointHistory';
+import * as Response from '@/lib/http/responses';
 
 /**
  * Retrieves point history records related to a specific product
@@ -26,7 +26,7 @@ export async function GET(
     }
     
     try{
-        const pointHistory = await Action.findPointHistoryByProduct(productIDInt);
+        const pointHistory = await Service.findPointHistoryByProduct(productIDInt);
         
         if (!pointHistory) {
             return Response.notFoundResponse(404);

--- a/application/src/app/api/priceHistory/byID/[priceHistoryID]/route.ts
+++ b/application/src/app/api/priceHistory/byID/[priceHistoryID]/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server';
-import * as Action from '@/action/priceHistory'
+import * as Service from '@/service/server/priceHistory'
 import * as Response from '@/lib/http/responses'
 
 /**
@@ -21,7 +21,7 @@ export async function GET(request: NextRequest, {params}:{ params: { priceHistor
     }
 
     try{
-        const priceHistory = await Action.findPriceHistory(priceHistoryIDInt);
+        const priceHistory = await Service.findPriceHistory(priceHistoryIDInt);
         
         if (!priceHistory) {
             return Response.notFoundResponse(404);

--- a/application/src/app/api/priceHistory/byProductID/[productID]/route.ts
+++ b/application/src/app/api/priceHistory/byProductID/[productID]/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server';
-import * as Action from '@/action/priceHistory'
-import * as Response from '@/lib/http/responses'
+import * as Service from '@/service/server/priceHistory';
+import * as Response from '@/lib/http/responses';
 
 /**
  * Retrieves price history records for a specific product
@@ -26,7 +26,7 @@ export async function GET(
     }
 
     try{
-        const priceHistory = await Action.findPriceHistoryByProduct(productIDInt);
+        const priceHistory = await Service.findPriceHistoryByProduct(productIDInt);
 
         if (!priceHistory) {
             return Response.notFoundResponse(404);

--- a/application/src/app/api/product/byID/[productID]/route.ts
+++ b/application/src/app/api/product/byID/[productID]/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server';
-import * as Action from '@/action/product'
+import * as Service from '@/service/server/product'
 import * as Response from '@/lib/http/responses'
 
 /**
@@ -25,7 +25,7 @@ export async function GET(
         return Response.badRequestResponse(400);
     }
     try{
-        const product = await Action.findProduct(productIDInt);
+        const product = await Service.findProduct(productIDInt);
 
         if (!product) {
             return Response.notFoundResponse(404);

--- a/application/src/lib/http/responses.ts
+++ b/application/src/lib/http/responses.ts
@@ -1,24 +1,24 @@
 import { NextResponse } from "next/server";
 
-export function jsonResponse (data: any, status : number = 200):NextResponse {
+export function jsonResponse (data: any, status : number):NextResponse {
     return NextResponse.json(data, {
         status,
         headers: { 'Content-Type': 'application/json' }
-      });
+    });
 }
 
-export function successReponse(data: any, status:number):NextResponse {
+export function successReponse(data: any, status:number = 200):NextResponse {
     return jsonResponse(data, status);
 }
 
-export function badRequestResponse(status : number): NextResponse {
-    return jsonResponse(status);
+export function badRequestResponse(status : number = 400): NextResponse {
+    return jsonResponse(null, status);
 }
 
-export function notFoundResponse(status : number): NextResponse {
-    return jsonResponse(status);
+export function notFoundResponse(status : number = 404): NextResponse {
+    return jsonResponse(null, status);
 }
 
-export function serverErrorReponse(status : number):NextResponse {
-    return jsonResponse(status);
+export function serverErrorReponse(status : number = 500):NextResponse {
+    return jsonResponse(null, status);
 }

--- a/application/src/lib/utils/transform.ts
+++ b/application/src/lib/utils/transform.ts
@@ -1,0 +1,42 @@
+
+import * as Api from '@/types/client/api';
+import * as Server from '@/types/server';
+
+
+export async function transformProduct(serverProduct:Server.Product):Promise<Api.Product>{
+    const clientProduct : Api.Product = {
+        product_id: serverProduct.product_id,
+        product_name: serverProduct.product_name,
+        brand: serverProduct.brand,
+        image_url: serverProduct.image_url,
+        package_size: serverProduct.package_size,
+        package_unit: serverProduct.package_unit
+    }
+    return clientProduct;
+}
+
+export async function transformFlyer(serverFlyer:Server.Flyer):Promise<Api.Flyer>{
+    const result : Api.Flyer= {
+        flyer_id: serverFlyer.flyer_id,
+        valid_from: serverFlyer.valid_from,
+        valid_to: serverFlyer.valid_to
+    }
+    return result;
+}
+
+export async function transformPriceHistory(serverPriceHistory:Server.PriceHistory):Promise<Api.PriceHistory>{
+    const clientPriceHistory : Api.PriceHistory = {
+        price_history_id: serverPriceHistory.price_history_id,
+        price: serverPriceHistory.price,
+        unit: serverPriceHistory.unit
+    }
+    return clientPriceHistory;
+}
+
+export async function transformPointHistory(serverPointHistory:Server.PointHistory):Promise<Api.PointHistory>{
+    const clientPointHistory : Api.PointHistory= {
+        point_history_id: serverPointHistory.point_history_id,
+        point: serverPointHistory.point
+    }
+    return clientPointHistory;
+}

--- a/application/src/service/api/product.ts
+++ b/application/src/service/api/product.ts
@@ -1,0 +1,30 @@
+import { Product } from "@/types/client/api";
+
+export async function FetchProductAPI(productID: string):Promise<{status: number; data : Product | null;}>{
+
+    if (!productID || isNaN(parseInt(productID))) {
+        return { status: 400, data: null };
+    }
+
+    try {
+        const response = await fetch(`/api/product/byID/${productID}`, {
+            method: "GET",
+            headers: {
+                'Content-Type': 'application/json',
+            },
+        });
+    
+        const data = await response.json();
+        if (!response.ok) {
+            return {status: response.status, data:null};
+        } 
+            
+        return { status: 200, data: data as Product};
+    
+    } catch (error) {
+        // This is temporarily approach, it will be handle in Logging entry later on
+        console.error('Error fetching product:', error);
+        return {status: 500, data:null}; 
+    }
+
+}

--- a/application/src/service/server/flyer.ts
+++ b/application/src/service/server/flyer.ts
@@ -1,0 +1,18 @@
+import * as Server from '@/types/server/flyer';
+import * as Api from '@/types/client/api';
+import * as Query from '@/lib/db/queries/flyer'
+import * as Transform from '@/lib/utils/transform';
+
+export async function findAllFlyers():Promise<Api.Flyer[]|null>{
+    const flyers:Server.Flyer[] | null = await Query.GetAllFlyers();
+    if(flyers && flyers.length>0){
+        const clientFlyers: Api.Flyer[] = await Promise.all(flyers.map(Transform.transformFlyer));
+        return clientFlyers;
+    }
+    return null;
+}
+
+export async function findFlyer(flyerid:number):Promise<Api.Flyer|null>{
+    const flyer: Server.Flyer | null = await Query.GetFlyerByID(flyerid);
+    return flyer ? await Transform.transformFlyer(flyer) : null;
+}

--- a/application/src/service/server/pointHistory.ts
+++ b/application/src/service/server/pointHistory.ts
@@ -1,0 +1,15 @@
+import * as Server from '@/types/server/product';
+import * as Api from '@/types/client/api';
+import * as Query from '@/lib/db/queries/pointHistory'
+import * as Transform from '@/lib/utils/transform';
+
+export async function findPointHistory(pointHistoryId:number):Promise<Api.PointHistory|null>{
+    const pointHistory:Server.PointHistory | null = await Query.GetPointHistoryByID(pointHistoryId);
+    return pointHistory? await Transform.transformPointHistory(pointHistory): null; 
+}
+
+
+export async function findPointHistoryByProduct(product_id: number):Promise<Api.PointHistory[]|null>{
+    const pointHistory:Server.PointHistory[] | null = await Query.GetPointHistoryByProduct(product_id);
+    return pointHistory? await Promise.all(pointHistory.map(Transform.transformPointHistory)): null; 
+}

--- a/application/src/service/server/priceHistory.ts
+++ b/application/src/service/server/priceHistory.ts
@@ -1,0 +1,14 @@
+import * as Server from '@/types/server/product';
+import * as Api from '@/types/client/api';
+import * as Query from '@/lib/db/queries/priceHistory'
+import * as Transform from '@/lib/utils/transform';
+
+export async function findPriceHistory(priceHistoryId:number):Promise<Api.PriceHistory|null>{
+    const priceHistory:Server.PriceHistory | null = await Query.GetPriceHistoryByID(priceHistoryId);
+    return priceHistory? await Transform.transformPriceHistory(priceHistory): null; 
+}
+
+export async function findPriceHistoryByProduct(product_id: number):Promise<Api.PriceHistory[]|null>{
+    const priceHistory:Server.PriceHistory[] | null = await Query.GetPriceHistoryByProduct(product_id);
+    return priceHistory? await Promise.all(priceHistory.map(Transform.transformPriceHistory)): null; 
+}

--- a/application/src/service/server/product.ts
+++ b/application/src/service/server/product.ts
@@ -1,0 +1,9 @@
+import * as Server from '@/types/server/product';
+import * as Api from '@/types/client/api';
+import * as Query from '@/lib/db/queries/product';
+import * as Transform from '@/lib/utils/transform';
+
+export async function findProduct(productid:number):Promise<Api.Product|null>{
+    const product:Server.Product | null = await Query.GetProductByID(productid);
+    return product? await Transform.transformProduct(product): null;
+}

--- a/application/src/types/client.ts
+++ b/application/src/types/client.ts
@@ -1,0 +1,1 @@
+export * from "./client/api";

--- a/application/src/types/client/api.ts
+++ b/application/src/types/client/api.ts
@@ -1,0 +1,25 @@
+export type Flyer = {
+    flyer_id: number;
+    valid_from: Date | null; 
+    valid_to: Date | null;  
+}
+
+export type Product ={
+    product_id: number,
+    product_name: string | null,
+    brand: string | null,
+    image_url: string | null,
+    package_size: number | null,
+    package_unit: string | null
+}
+
+export type PriceHistory = {
+    price_history_id: number,
+    price: number | null,
+    unit: string | null
+}
+
+export type PointHistory ={
+    point_history_id: number,
+    point: number | null
+}

--- a/application/src/types/server.ts
+++ b/application/src/types/server.ts
@@ -1,0 +1,3 @@
+export * from "./server/flyer";
+export * from "./server/grocery";
+export * from "./server/product";


### PR DESCRIPTION
Create dedicated service layer to separate data transformation from business logic and API routes. Reorganize type definitions for improved maintainability.

- Move transformation functions from action/ to new service/ folder
- Split service layer into api/ and server/ subfolders to mirror type structure
- Create utility transform functions in lib/utils/transform.ts
- Update all API route handlers to use the new service layer
- Reorganize type imports with centralized client.ts and server.ts entry points
- Update HTTP response handling in lib/http/responses.ts
