### PR TITLE
Build(dev): upgrade nextjs version to 14.2.25

### DIFF
--- a/application/package.json
+++ b/application/package.json
@@ -12,9 +12,9 @@
   "dependencies": {
     "drizzle-orm": "^0.33.0",
     "mysql2": "^3.11.0",
-    "next": "^14.0.0",
-    "react": "^18.0.0",
-    "react-dom": "^18.0.0"
+    "next": "14.2.25",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
   },
   "devDependencies": {
     "@types/node": "^20",


### PR DESCRIPTION
- Updates Next.js from ^14.0.0 to 14.2.25 to address https://github.com/advisories/GHSA-f82v-jwr5-mffw (https://github.com/advisories/GHSA-f82v-jwr5-mffw), a critical middleware authorization bypass vulnerability.
- Also bumps react and react-dom to ^18.2.0 for compatibility.
See https://github.com/advisories/GHSA-f82v-jwr5-mffw for details.